### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The tester will generate a test.txt. Deleting or modifying it doesn't affect the
 ---
 **NOTE: Set random.seed(1) at the beginning of n_queens_restart()!!!**
 
+**Don't freak out if n_queens_restart() fails. It requires you to generate a random state in a specific way.**
 The reference output was generated with random.seed(1) set at the beginning of the n_queens_restart() function.
 Make sure you do the same to ensure you get the same random number sequence.
 


### PR DESCRIPTION
https://github.com/cs540-testers/HW3-Tester/issues/2

I think the issue above is caused by the user creating his random state in a different way than the authors of this test. We should add a little warning about failures on n_queens_restart() to be expected. Not sure if sharing the implementation of how to generate the random state is allowed. 
